### PR TITLE
Round prometheus timestamps up to the nearest second.

### DIFF
--- a/backend/writer.go
+++ b/backend/writer.go
@@ -54,7 +54,12 @@ func (w *MetricWriter) writeMetrics(ts *prompb.TimeSeries) {
 			continue
 		}
 		source, finalTags := w.buildTags(tags)
-		err := w.sender.SendMetric(fieldName, value.Value, value.Timestamp, source, finalTags)
+		err := w.sender.SendMetric(
+			fieldName,
+			value.Value,
+			roundUpToNearestSecond(value.Timestamp),
+			source,
+			finalTags)
 		if err != nil {
 			log.Warnf("Cannot send metric: %s. Reason: %s. Skipping to next", fieldName, err)
 		}
@@ -110,4 +115,10 @@ func (w *MetricWriter) HealthCheck() (int, string) {
 		return 503, err.Error()
 	}
 	return 200, "OK"
+}
+
+// roundUpToNearestSecond rounds milliseconds up to the nearest second and
+// returns that value in millisecons. So 123000 -> 123000 and 123001 -> 124000
+func roundUpToNearestSecond(milliseconds int64) int64 {
+	return ((milliseconds + 1000 - 1) / 1000) * 1000
 }

--- a/backend/writer_test.go
+++ b/backend/writer_test.go
@@ -147,7 +147,7 @@ func TestRoundtrips(t *testing.T) {
 		case <-time.After(10 * time.Second):
 			t.Error("Timed out waiting for metrics")
 		case s := <-response:
-			linePrefix := fmt.Sprintf("\"%s\" 50 %d source=\"%s\"", test.finalMetric, timestamp, test.finalSource)
+			linePrefix := fmt.Sprintf("\"%s\" 50 %d source=\"%s\"", test.finalMetric, roundUpToNearestSecond(timestamp), test.finalSource)
 			require.Equal(t, linePrefix, s[0:len(linePrefix)])
 			r := []rune(s)
 			require.Equal(t, '\n', r[len(r)-1])


### PR DESCRIPTION
Rounding timestamps up to the nearest second before storing in wavefront is
necessary for the data in wavefront to match the data in prometheus.