### PR TITLE
Exclude tags for the filtered metrics

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -145,6 +145,10 @@ func main() {
 		log.Fatal(err)
 		return
 	}
+
+	if len(metricsFilter.filter) == 0 {
+		metricsFilter.filter = make(map[string]string, 0)
+	}
 	mw := backend.NewMetricWriter(sender, prefix, parseTags(tags), convertPaths, metricsFilter.filter)
 
 	// Install metric receiver

--- a/backend/writer.go
+++ b/backend/writer.go
@@ -43,11 +43,26 @@ func (w *MetricWriter) Write(rq prompb.WriteRequest) {
 
 func (w *MetricWriter) writeMetrics(ts *prompb.TimeSeries) {
 	tags := make(map[string]string, len(ts.Labels))
+	var fieldName string
+
 	for _, l := range ts.Labels {
 		tagName := w.buildTagName(l.Name)
 		tags[tagName] = l.Value
 	}
-	fieldName := w.buildMetricName(tags["__name__"])
+	fieldName = w.buildMetricName(tags["__name__"])
+
+	if val, ok := w.filters[tags["__name__"]]; ok {
+		//if the metric is present in the filter then we are going to ignore it.
+		// We are going to return the name which came in filter, a custom value.
+		// No prefix should be appended to this metrics.
+		// We are also avoiding any transformation to their tags.
+		tags = make(map[string]string, len(ts.Labels))
+		for _, l := range ts.Labels {
+			tags[l.Name] = l.Value
+		}
+		fieldName = val
+	}
+
 	delete(tags, "__name__")
 	for _, value := range ts.Samples {
 		// Prometheus sometimes sends NaN samples. We interpret them as
@@ -69,21 +84,6 @@ func (w *MetricWriter) writeMetrics(ts *prompb.TimeSeries) {
 }
 
 func (w *MetricWriter) buildMetricName(name string) string {
-	//if the metric is present in the filter then we are going to ignore it.
-	// We are going to return the name which came in filter, a custom value.
-	// No prefix should be appended to this metrics.
-	//if user by mistake just pass "key1=" we are going to let it through normal process.
-
-	if len(w.filters) != 0 {
-		if val, ok := w.filters[name]; ok {
-			if val != "" {
-				return val
-			} else {
-				log.Debugf("filter %s came with out value, this is incorrect.", name)
-			}
-		}
-	}
-
 	if w.prefix != "" {
 		name = w.prefix + "_" + name
 	}


### PR DESCRIPTION
The tags for the metrics that are filtered to ensure no modifications are applied to them are also being modified.

This patch avoids any modification to any tag belonging to a filtered metric.